### PR TITLE
Add a CI script before each push

### DIFF
--- a/git_template/hooks/pre-push
+++ b/git_template/hooks/pre-push
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+scriptName=customTesting.js
+
+if [ -e ${scriptName} ]; then
+  echo -n "Sending test results to Sparta Server..."
+  npm test &> /dev/null
+  echo "✓"
+fi
+exit 0

--- a/gitconfig
+++ b/gitconfig
@@ -16,6 +16,10 @@
 
   prune = true
 
+[init]
+
+  templatedir = ~/.git_template
+
 [grep]
 
   extendRegexp = true


### PR DESCRIPTION
I wanted to have it run in background (detached from the terminal) but
it looks like OSX (or iTerm2) doesn't play well with `nohup` and `disown`.
The hook hangs until the end of the script so I just decided to display a
"nice" message... :(