### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ Link dotfiles:
 rcup -d ~/Workspace/dotfiles
 ```
 
-Change shell to use `zsh`:
-
-```sh
-chsh -s /bin/zsh
-```
+Open iTerm
 
 If you run into a warning with `compaudit`, fix permissions with:
 


### PR DESCRIPTION
- Changing to zsh is no longer necessary, it's the default on macOS
- Forcing opening iTerm allow for accepting the app downloaded from internet and I didn't see the compaudit errors in terminal